### PR TITLE
Adds support for the Flusher and Hijacker interfaces

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,8 +1,11 @@
 package logger
 
 import (
+	"bufio"
+	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"time"
@@ -109,6 +112,19 @@ func (c *customResponseWriter) Write(b []byte) (int, error) {
 	size, err := c.ResponseWriter.Write(b)
 	c.size += size
 	return size, err
+}
+
+func (c *customResponseWriter) Flush() {
+	if f, ok := c.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (c *customResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := c.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, fmt.Errorf("ResponseWriter does not implement the Hijacker interface")
 }
 
 func newCustomResponseWriter(w http.ResponseWriter) *customResponseWriter {


### PR DESCRIPTION
Something I noticed when working with websocekts and trying to either use the
`Flusher()` interface or teh `Hijacker()` interface. This fixes the missing
interfaces so this works correctly.